### PR TITLE
feat: Add test suite for main.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+greenlet==3.2.3
+playwright==1.54.0
+pyee==13.0.0
+typing_extensions==4.14.1
+pytest
+pytest-mock
+python-dotenv
+openai

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,182 @@
+import pytest
+from unittest.mock import patch, MagicMock, mock_open
+import main
+import sys
+import subprocess
+import os
+
+@patch('subprocess.check_call')
+def test_check_pip_exists(mock_check_call):
+    """
+    Test that check_pip returns True when pip is found.
+    """
+    assert main.check_pip() is True
+    mock_check_call.assert_called_once_with([sys.executable, "-m", "pip", "--version"])
+
+@patch('subprocess.check_call', side_effect=subprocess.CalledProcessError(1, 'cmd'))
+def test_check_pip_not_exists(mock_check_call):
+    """
+    Test that check_pip returns False when pip is not found.
+    """
+    assert main.check_pip() is False
+    mock_check_call.assert_called_once_with([sys.executable, "-m", "pip", "--version"])
+
+@patch('subprocess.check_call', side_effect=FileNotFoundError)
+def test_check_pip_file_not_found(mock_check_call):
+    """
+    Test that check_pip returns False when python executable is not found.
+    """
+    assert main.check_pip() is False
+    mock_check_call.assert_called_once_with([sys.executable, "-m", "pip", "--version"])
+
+@patch('urllib.request.urlretrieve')
+@patch('subprocess.check_call')
+@patch('os.remove')
+def test_install_pip(mock_remove, mock_check_call, mock_urlretrieve):
+    """
+    Test that install_pip downloads and installs pip.
+    """
+    main.install_pip()
+    mock_urlretrieve.assert_called_once_with("https://bootstrap.pypa.io/get-pip.py", "get-pip.py")
+    mock_check_call.assert_called_once_with([sys.executable, "get-pip.py", "--user"])
+    mock_remove.assert_called_once_with("get-pip.py")
+
+@patch('subprocess.check_call')
+def test_install_package(mock_check_call):
+    """
+    Test that install_package calls pip to install a package.
+    """
+    main.install_package("my-package")
+    mock_check_call.assert_called_once_with([sys.executable, "-m", "pip", "install", "--user", "my-package"])
+
+@patch('shutil.which')
+def test_command_exists(mock_which):
+    """
+    Test that command_exists returns True when a command exists.
+    """
+    mock_which.return_value = '/usr/bin/test'
+    assert main.command_exists("test") is True
+    mock_which.assert_called_once_with("test")
+
+@patch('shutil.which')
+def test_command_does_not_exist(mock_which):
+    """
+    Test that command_exists returns False when a command does not exist.
+    """
+    mock_which.return_value = None
+    assert main.command_exists("test") is False
+    mock_which.assert_called_once_with("test")
+
+@patch('subprocess.check_call')
+def test_install_homebrew(mock_check_call):
+    """
+    Test that install_homebrew runs the Homebrew installation script.
+    """
+    main.install_homebrew()
+    install_cmd = '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+    mock_check_call.assert_called_once_with(install_cmd, shell=True)
+
+@patch('subprocess.check_call')
+@patch.dict(os.environ, {'Path': ''}, clear=True)
+def test_install_chocolatey(mock_check_call):
+    """
+    Test that install_chocolatey runs the Chocolatey installation script.
+    """
+    main.install_chocolatey()
+    install_cmd = (
+        "Set-ExecutionPolicy Bypass -Scope Process -Force; "
+        "[System.Net.ServicePointManager]::SecurityProtocol = "
+        "[System.Net.ServicePointManager]::SecurityProtocol -bor 3072; "
+        "iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))"
+    )
+    mock_check_call.assert_called_once_with(["powershell.exe", "-Command", install_cmd])
+
+@patch('main.OpenAI')
+def test_generate_playbook(mock_openai):
+    """
+    Test that generate_playbook calls the OpenAI API with the correct prompt.
+    """
+    mock_client = MagicMock()
+    mock_openai.return_value = mock_client
+    mock_client.chat.completions.create.return_value.choices[0].message.content = "playbook_content"
+
+    result = main.generate_playbook(mock_client, "macOS", ["vim", "git"])
+    assert result == "playbook_content"
+    mock_client.chat.completions.create.assert_called_once()
+    prompt = mock_client.chat.completions.create.call_args[1]['messages'][0]['content']
+    assert "Create an Ansible playbook YAML for macOS" in prompt
+    assert "vim, git" in prompt
+
+@patch('main.OpenAI')
+def test_generate_playbook_with_error(mock_openai):
+    """
+    Test that generate_playbook calls the OpenAI API with a prompt to fix an error.
+    """
+    mock_client = MagicMock()
+    mock_openai.return_value = mock_client
+    mock_client.chat.completions.create.return_value.choices[0].message.content = "fixed_playbook_content"
+
+    result = main.generate_playbook(mock_client, "macOS", ["vim", "git"], error="some error", previous_content="previous_content")
+    assert result == "fixed_playbook_content"
+    mock_client.chat.completions.create.assert_called_once()
+    prompt = mock_client.chat.completions.create.call_args[1]['messages'][0]['content']
+    assert "Fix this Ansible playbook YAML for macOS" in prompt
+    assert "some error" in prompt
+    assert "previous_content" in prompt
+    assert "vim, git" in prompt
+
+@patch('platform.system', return_value='darwin')
+@patch('main.check_pip', return_value=True)
+@patch('main.install_pip')
+@patch('main.install_package')
+@patch('main.load_dotenv')
+@patch('main.OpenAI')
+@patch('builtins.input', return_value='vim, git')
+@patch('main.command_exists')
+@patch('main.install_homebrew')
+@patch('subprocess.check_call')
+@patch('subprocess.check_output', return_value=b'Syntax check passed')
+@patch('builtins.open', new_callable=mock_open)
+@patch('main.advise_path_update')
+def test_main_macos(
+    mock_advise, mock_open_file, mock_check_output, mock_check_call,
+    mock_install_homebrew, mock_command_exists, mock_input, mock_openai,
+    mock_load_dotenv, mock_install_package, mock_install_pip, mock_check_pip, mock_system
+):
+    """
+    Test the main function on macOS.
+    """
+    # Simulate that brew and ansible are not installed initially, but are installed later.
+    mock_command_exists.side_effect = [
+        False, # ansible-playbook not found
+        False, # brew not found
+        True,  # ansible-playbook found after install
+        True   # brew found after program install
+    ]
+    os.environ['OPENAI_API_KEY'] = 'test_key'
+
+    main.main()
+
+    # Check that the correct functions were called
+    mock_check_pip.assert_called_once()
+    mock_install_pip.assert_not_called()
+    assert mock_install_package.call_count == 2
+    mock_load_dotenv.assert_called_once()
+    mock_openai.assert_called_once()
+    mock_input.assert_called_once()
+    assert mock_command_exists.call_count == 4
+    mock_install_homebrew.assert_called_once()
+
+    # Check ansible installation calls
+    assert any(['brew', 'install', 'ansible'] in call.args for call in mock_check_call.call_args_list)
+
+    # Check program installation calls
+    assert any(['brew', 'install', 'vim', 'git'] in call.args for call in mock_check_call.call_args_list)
+
+    # Check playbook generation and execution
+    mock_open_file.assert_called_with('ansible_playbook.yml', 'w')
+    mock_check_output.assert_called_with(
+        ['ansible-playbook', 'ansible_playbook.yml', '--syntax-check'],
+        stderr=subprocess.STDOUT
+    )
+    assert any(['ansible-playbook', 'ansible_playbook.yml'] in call.args for call in mock_check_call.call_args_list)


### PR DESCRIPTION
This commit introduces a comprehensive test suite for the `main.py` script.

The test suite uses `pytest` and `pytest-mock` to test the functionality of the script in a controlled environment.

The following aspects of the script are covered:
- Helper functions for installation of dependencies (pip, packages).
- Command existence checks.
- Platform-specific installation logic (macOS, Windows).
- AI-based Ansible playbook generation.
- The main application flow for macOS.

The tests mock all external dependencies, including file system operations, subprocess calls, and network requests, to ensure they are fast and reliable.