### PR TITLE
feat: Add choice for default or custom program list

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,12 @@ import os
 import urllib.request
 import shutil
 
+DEFAULT_PROGRAMS = {
+    "linux": ["vlc", "docker.io", "git", "code"],
+    "darwin": ["vlc", "docker", "git", "visual-studio-code", "google-chrome"],
+    "windows": ["vlc", "docker-desktop", "git", "vscode", "googlechrome"]
+}
+
 def check_pip():
     try:
         subprocess.check_call([sys.executable, "-m", "pip", "--version"])
@@ -120,6 +126,23 @@ def ensure_ansible_installed():
         sys.exit(1)
     print("Ansible installed successfully.")
 
+def get_program_list(os_name):
+    while True:
+        choice = input(
+            "Choose an option:\n"
+            "a. Install a default list of applications (VLC, Docker, etc.)\n"
+            "b. Enter a custom list of programs\n"
+            "Your choice: "
+        ).lower()
+
+        if choice == 'a':
+            return DEFAULT_PROGRAMS.get(os_name, [])
+        elif choice == 'b':
+            programs_input = input("Enter the list of programs to install, separated by commas: ").strip()
+            return [p.strip() for p in programs_input.split(',') if p.strip()]
+        else:
+            print("Invalid choice. Please enter 'a' or 'b'.")
+
 def main():
     os_name = platform.system().lower()
 
@@ -155,8 +178,7 @@ def main():
         print("Ansible does not support Windows as a control machine natively.")
         print("Skipping Ansible installation. Proceeding with program installation if applicable.")
 
-    programs_input = input("Enter the list of programs to install, separated by commas: ").strip()
-    programs = [p.strip() for p in programs_input.split(',') if p.strip()]
+    programs = get_program_list(os_name)
 
     if not programs:
         print("No programs specified.")

--- a/test_main.py
+++ b/test_main.py
@@ -132,7 +132,7 @@ def test_generate_playbook_with_error():
 @patch('main.install_package')
 @patch('dotenv.load_dotenv')
 @patch('openai.OpenAI')
-@patch('builtins.input', return_value='vim, git')
+@patch('builtins.input', side_effect=['b', 'vim, git'])
 @patch('main.command_exists')
 @patch('main.install_homebrew')
 @patch('subprocess.check_call')
@@ -165,7 +165,7 @@ def test_main_macos(
     assert mock_install_package.call_count == 2
     mock_load_dotenv.assert_called_once()
     mock_openai.assert_called_once()
-    mock_input.assert_called_once()
+    assert mock_input.call_count == 2
     assert mock_command_exists.call_count == 4
     mock_install_homebrew.assert_called_once()
 


### PR DESCRIPTION
This commit introduces a new feature that allows the user to choose between installing a predefined default list of applications or entering a custom list of programs.

- A `DEFAULT_PROGRAMS` dictionary is added to store the default applications for different operating systems (Linux, macOS, Windows).
- A new function `get_program_list` is created to handle the user interaction for choosing between the default and custom lists.
- The `main` function is updated to use the new `get_program_list` function.
- The tests are updated to reflect the new user input flow.