### PR TITLE
feat: Add expanded program lists and verbose playbook output

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,10 +7,16 @@ import os
 import urllib.request
 import shutil
 
-DEFAULT_PROGRAMS = {
+BASIC_PROGRAMS = {
     "linux": ["vlc", "docker.io", "git", "code"],
     "darwin": ["vlc", "docker", "git", "visual-studio-code", "google-chrome"],
     "windows": ["vlc", "docker-desktop", "git", "vscode", "googlechrome"]
+}
+
+DEVELOPER_PROGRAMS = {
+    "linux": ["git", "docker.io", "code", "postman", "dbeaver-ce", "libreoffice", "evince", "slack", "vlc", "gimp", "spotify-client"],
+    "darwin": ["git", "docker", "visual-studio-code", "postman", "dbeaver-community", "libreoffice", "adobe-acrobat-reader", "slack", "vlc", "gimp", "spotify"],
+    "windows": ["git", "docker-desktop", "vscode", "postman", "dbeaver", "libreoffice", "adobereader", "slack", "vlc", "gimp", "spotify"]
 }
 
 def check_pip():
@@ -154,18 +160,21 @@ def get_program_list(os_name):
     while True:
         choice = input(
             "Choose an option:\n"
-            "a. Install a default list of applications (VLC, Docker, etc.)\n"
-            "b. Enter a custom list of programs\n"
+            "a. Install a basic list of applications.\n"
+            "b. Install a full developer list of applications.\n"
+            "c. Enter a custom list of programs.\n"
             "Your choice: "
         ).lower()
 
         if choice == 'a':
-            return DEFAULT_PROGRAMS.get(os_name, [])
+            return BASIC_PROGRAMS.get(os_name, [])
         elif choice == 'b':
+            return DEVELOPER_PROGRAMS.get(os_name, [])
+        elif choice == 'c':
             programs_input = input("Enter the list of programs to install, separated by commas: ").strip()
             return [p.strip() for p in programs_input.split(',') if p.strip()]
         else:
-            print("Invalid choice. Please enter 'a' or 'b'.")
+            print("Invalid choice. Please enter 'a', 'b', or 'c'.")
 
 def main():
     os_name = platform.system().lower()
@@ -328,7 +337,7 @@ def main():
         try:
             print(f"Attempt {attempt + 1}: Checking playbook syntax...")
             output = subprocess.check_output(
-                ['ansible-playbook', playbook_file, '--syntax-check'],
+                ['ansible-playbook', playbook_file, '--syntax-check', '-v'],
                 stderr=subprocess.STDOUT
             ).decode('utf-8')
             print("Syntax check output:")
@@ -353,7 +362,7 @@ def main():
     # Run the playbook
     try:
         print("Running the playbook...")
-        subprocess.check_call(['ansible-playbook', playbook_file])
+        subprocess.check_call(['ansible-playbook', playbook_file, '-v'])
         print("Playbook executed successfully.")
     except subprocess.CalledProcessError as e:
         print(f"Error running playbook: {e}")

--- a/test_main.py
+++ b/test_main.py
@@ -171,13 +171,37 @@ def test_generate_playbook_fallback_fails(mock_sleep):
     ])
     assert mock_sleep.call_count == 6
 
+@patch('builtins.input', return_value='a')
+def test_get_program_list_basic(mock_input):
+    """
+    Test that get_program_list returns the basic list when 'a' is chosen.
+    """
+    programs = main.get_program_list('darwin')
+    assert programs == main.BASIC_PROGRAMS['darwin']
+
+@patch('builtins.input', return_value='b')
+def test_get_program_list_developer(mock_input):
+    """
+    Test that get_program_list returns the developer list when 'b' is chosen.
+    """
+    programs = main.get_program_list('windows')
+    assert programs == main.DEVELOPER_PROGRAMS['windows']
+
+@patch('builtins.input', side_effect=['c', 'custom-prog1, custom-prog2'])
+def test_get_program_list_custom(mock_input):
+    """
+    Test that get_program_list returns a custom list when 'c' is chosen.
+    """
+    programs = main.get_program_list('linux')
+    assert programs == ['custom-prog1', 'custom-prog2']
+
 @patch('platform.system', return_value='darwin')
 @patch('main.check_pip', return_value=True)
 @patch('main.install_pip')
 @patch('main.install_package')
 @patch('dotenv.load_dotenv')
 @patch('openai.OpenAI')
-@patch('builtins.input', side_effect=['b', 'vim, git'])
+@patch('builtins.input', side_effect=['c', 'vim, git'])
 @patch('main.command_exists')
 @patch('main.install_homebrew')
 @patch('subprocess.check_call')
@@ -225,7 +249,7 @@ def test_main_macos(
     mock_open_file.assert_called_with('ansible_playbook.yml', 'w')
     mock_open_file().write.assert_called_once_with('generated_playbook_content')
     mock_check_output.assert_called_with(
-        ['ansible-playbook', 'ansible_playbook.yml', '--syntax-check'],
+        ['ansible-playbook', 'ansible_playbook.yml', '--syntax-check', '-v'],
         stderr=subprocess.STDOUT
     )
-    assert any(['ansible-playbook', 'ansible_playbook.yml'] in call.args for call in mock_check_call.call_args_list)
+    assert any(['ansible-playbook', 'ansible_playbook.yml', '-v'] in call.args for call in mock_check_call.call_args_list)


### PR DESCRIPTION
This commit introduces the final set of features and improvements based on iterative user feedback.

- The program selection menu has been expanded to three options:
  1. A basic list of essential applications.
  2. A full developer-focused list of applications.
  3. A custom user-provided list.
- The `DEFAULT_PROGRAMS` dictionary has been split into `BASIC_PROGRAMS` and `DEVELOPER_PROGRAMS` to support this new structure.
- The `-v` (verbose) flag has been added to both the `ansible-playbook` syntax check and execution commands to provide more detailed output and aid in debugging.
- All related tests have been updated to reflect and verify this new functionality.

This commit concludes a series of user-driven enhancements to the script, building upon the previously added features like model fallback and linear backoff for API retries.