### PR TITLE
fix: Handle pip install in virtual environments

### DIFF
--- a/src/program_installer/main.py
+++ b/src/program_installer/main.py
@@ -39,7 +39,12 @@ def install_pip():
 
 def install_package(package):
     print(f"Installing {package}...")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "--user", package])
+    command = [sys.executable, "-m", "pip", "install", package]
+    # If not in a virtual environment, install to user site-packages
+    if sys.prefix == sys.base_prefix:
+        command.insert(4, "--user")
+
+    subprocess.check_call(command)
     print(f"{package} installed successfully.")
 
 def command_exists(cmd):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,6 +49,28 @@ def test_install_package(mock_check_call):
     main.install_package("my-package")
     mock_check_call.assert_called_once_with([sys.executable, "-m", "pip", "install", "--user", "my-package"])
 
+@patch('subprocess.check_call')
+@patch('sys.prefix', '/usr')
+@patch('sys.base_prefix', '/usr')
+def test_install_package_no_venv(mock_check_call):
+    """
+    Test that install_package uses --user when not in a venv.
+    """
+    main.install_package("my-package")
+    expected_command = [sys.executable, "-m", "pip", "install", "--user", "my-package"]
+    mock_check_call.assert_called_once_with(expected_command)
+
+@patch('subprocess.check_call')
+@patch('sys.prefix', '/app/.venv')
+@patch('sys.base_prefix', '/usr')
+def test_install_package_in_venv(mock_check_call):
+    """
+    Test that install_package does not use --user when in a venv.
+    """
+    main.install_package("my-package")
+    expected_command = [sys.executable, "-m", "pip", "install", "my-package"]
+    mock_check_call.assert_called_once_with(expected_command)
+
 @patch('shutil.which')
 def test_command_exists(mock_which):
     """


### PR DESCRIPTION
This commit fixes a runtime error that occurred when running the script inside a virtual environment. The `pip install --user` command is not compatible with virtualenvs and was causing the script to crash.

- The `install_package` function has been updated to detect if the script is running inside a virtual environment.
- The `--user` flag is now only added to the `pip install` command when the script is running outside of a virtual environment.
- New tests have been added to verify this conditional logic.

This fix is part of a larger series of user-driven enhancements, including the full project packaging and CI/CD workflow.